### PR TITLE
Stop trying to update the comment - LEAN-992

### DIFF
--- a/src/hooks/use-comments.ts
+++ b/src/hooks/use-comments.ts
@@ -33,7 +33,6 @@ import {
 import { Command } from 'prosemirror-commands'
 import { Node as ProsemirrorNode } from 'prosemirror-model'
 import { useCallback, useEffect, useState } from 'react'
-import { v4 as uuid } from 'uuid'
 
 import { CommentFilter } from '../components/projects/CommentListPatterns'
 import { useStore } from '../store'


### PR DESCRIPTION
While we are trying to update the comments selectors, we are getting sync errors due to missing channel access.
(Note: system user is the owner of these comments created in [manuscripts-manuscript-transform!289 (merged)](https://gitlab.com/mpapp-public/manuscripts-manuscript-transform/-/merge_requests/289))

Discussion around this in https://jira.atypon.com/browse/LEAN-992?focusedCommentId=4942602&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-4942602