### PR TITLE
Update comment position

### DIFF
--- a/src/hooks/use-comments.ts
+++ b/src/hooks/use-comments.ts
@@ -295,14 +295,18 @@ export const useComments = (
         return
       }
 
-      const maybeInsert = insertAnnotationFromComment({
+      saveComment({
         ...comment,
         selector: { from, to },
       })
-      if (!maybeInsert) {
-        return
-      }
-      return doCommand(maybeInsert)
+        .then((comment) => {
+          const maybeInsert = insertAnnotationFromComment(comment)
+          if (!maybeInsert) {
+            return
+          }
+          return doCommand(maybeInsert)
+        })
+        .catch(console.error)
     })
 
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
This is to revert the change on https://github.com/Atypon-OpenSource/manuscripts-article-editor/pull/7 until we decide if we want to update permissions (sync-function) to allow updating the comment.