### PR TITLE
Paginate results implementation for PE & CE (LEAN-582)

### DIFF
--- a/src/EditorApp.tsx
+++ b/src/EditorApp.tsx
@@ -60,7 +60,7 @@ const EditorApp: React.FC<Props> = ({ submissionId }) => {
     if (!data?.submission?.documentId) {
       return
     }
-    const [projectID, manuscriptID] = data?.submission?.documentId.split('#')
+    const [projectID, manuscriptID] = data.submission.documentId.split('#')
 
     // implement remount for the store if component is retriggered
     const basicSource = new BasicSource(

--- a/src/EditorApp.tsx
+++ b/src/EditorApp.tsx
@@ -62,6 +62,8 @@ const EditorApp: React.FC<Props> = ({
       submissionId,
       projectID,
       manuscriptID,
+      submission,
+      person,
       userID || ''
     )
     const couchSource = new CouchSource()
@@ -83,10 +85,7 @@ const EditorApp: React.FC<Props> = ({
         <NotificationProvider>
           <Page>
             <Wrapper>
-              <ManuscriptPageContainer
-                submission={submission}
-                person={person}
-              />
+              <ManuscriptPageContainer />
             </Wrapper>
           </Page>
         </NotificationProvider>

--- a/src/EditorApp.tsx
+++ b/src/EditorApp.tsx
@@ -9,7 +9,6 @@
  *
  * All portions of the code written by Atypon Systems LLC are Copyright (c) 2019 Atypon Systems LLC. All Rights Reserved.
  */
-import { ApolloError } from 'apollo-client'
 import React, { useEffect, useState } from 'react'
 import { hot } from 'react-hot-loader'
 import { BrowserRouter as Router } from 'react-router-dom'
@@ -17,17 +16,10 @@ import styled from 'styled-components'
 
 import { NotificationProvider } from './components/NotificationProvider'
 import { Page } from './components/Page'
-import {
-  ManuscriptPlaceholder,
-  ProjectPlaceholder,
-} from './components/Placeholders'
+import { ProjectPlaceholder } from './components/Placeholders'
 import ManuscriptPageContainer from './components/projects/lean-workflow/ManuscriptPageContainerLW'
-import { ReloadDialog } from './components/projects/ReloadDialog'
 import CouchSource from './couch-data/CouchSource'
-import {
-  graphQLErrorMessage,
-  useGetSubmissionAndPerson,
-} from './lib/lean-workflow-gql'
+import { Person, Submission } from './lib/lean-workflow-gql'
 import { getCurrentUserId } from './lib/user'
 import {
   BasicSource,
@@ -38,6 +30,10 @@ import {
 
 interface Props {
   submissionId: string
+  manuscriptID: string
+  projectID: string
+  submission: Submission
+  person: Person
 }
 
 const Wrapper = styled.div`
@@ -50,18 +46,17 @@ const Wrapper = styled.div`
   font-family: Lato, sans-serif;
 `
 
-const EditorApp: React.FC<Props> = ({ submissionId }) => {
-  const { data, loading, error } = useGetSubmissionAndPerson(submissionId)
-
+const EditorApp: React.FC<Props> = ({
+  submissionId,
+  manuscriptID,
+  projectID,
+  submission,
+  person,
+}) => {
   const userID = getCurrentUserId()
   const [store, setStore] = useState<GenericStore>()
 
   useEffect(() => {
-    if (!data?.submission?.documentId) {
-      return
-    }
-    const [projectID, manuscriptID] = data.submission.documentId.split('#')
-
     // implement remount for the store if component is retriggered
     const basicSource = new BasicSource(
       submissionId,
@@ -80,19 +75,7 @@ const EditorApp: React.FC<Props> = ({ submissionId }) => {
     return () => store?.unmount()
 
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [submissionId, data?.submission?.documentId])
-
-  if (loading) {
-    return <ManuscriptPlaceholder />
-  }
-
-  if (error) {
-    const message = graphQLErrorMessage(
-      error as ApolloError,
-      'Request for user permissions from server failed.'
-    )
-    return <ReloadDialog message={message} />
-  }
+  }, [submissionId, manuscriptID, projectID])
 
   return store ? (
     <GenericStoreProvider store={store}>
@@ -101,8 +84,8 @@ const EditorApp: React.FC<Props> = ({ submissionId }) => {
           <Page>
             <Wrapper>
               <ManuscriptPageContainer
-                submission={data.submission}
-                person={data.person}
+                submission={submission}
+                person={person}
               />
             </Wrapper>
           </Page>

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -20,23 +20,40 @@ import { ModalProvider } from './components/ModalHookableProvider'
 import { ServiceWorker } from './components/ServiceWorker'
 import EditorApp from './EditorApp'
 import { apolloClient } from './lib/apollo'
+import { Person, Submission } from './lib/lean-workflow-gql'
 import { GlobalStyle } from './theme/theme'
 
 interface Props {
   submissionId: string
+  manuscriptID: string
+  projectID: string
+  submission: Submission
+  person: Person
 }
 
 // submissionId="13f64873-a9bf-4d88-a44a-2a25f9e49fc3"
 // manuscriptID="MPProject:E1895468-4DFE-4F17-9B06-5212ECD29555"
 // projectID="MPManuscript:5F6D807F-CECF-45D0-B94C-5CF1361BDF05"
 
-const Main: React.FC<Props> = ({ submissionId }) => (
+const Main: React.FC<Props> = ({
+  submissionId,
+  manuscriptID,
+  projectID,
+  submission,
+  person,
+}) => (
   <DndProvider backend={HTML5Backend}>
     <GlobalStyle />
     <ServiceWorker />
     <ModalProvider>
       <ApolloProvider client={apolloClient}>
-        <EditorApp submissionId={submissionId} />
+        <EditorApp
+          submissionId={submissionId}
+          manuscriptID={manuscriptID}
+          projectID={projectID}
+          submission={submission}
+          person={person}
+        />
       </ApolloProvider>
     </ModalProvider>
   </DndProvider>

--- a/src/Main.tsx
+++ b/src/Main.tsx
@@ -24,25 +24,19 @@ import { GlobalStyle } from './theme/theme'
 
 interface Props {
   submissionId: string
-  manuscriptID: string
-  projectID: string
 }
 
 // submissionId="13f64873-a9bf-4d88-a44a-2a25f9e49fc3"
 // manuscriptID="MPProject:E1895468-4DFE-4F17-9B06-5212ECD29555"
 // projectID="MPManuscript:5F6D807F-CECF-45D0-B94C-5CF1361BDF05"
 
-const Main: React.FC<Props> = ({ submissionId, manuscriptID, projectID }) => (
+const Main: React.FC<Props> = ({ submissionId }) => (
   <DndProvider backend={HTML5Backend}>
     <GlobalStyle />
     <ServiceWorker />
     <ModalProvider>
       <ApolloProvider client={apolloClient}>
-        <EditorApp
-          submissionId={submissionId}
-          manuscriptID={manuscriptID}
-          projectID={projectID}
-        />
+        <EditorApp submissionId={submissionId} />
       </ApolloProvider>
     </ModalProvider>
   </DndProvider>

--- a/src/components/projects/lean-workflow/ManuscriptPageContainerLW.tsx
+++ b/src/components/projects/lean-workflow/ManuscriptPageContainerLW.tsx
@@ -34,7 +34,6 @@ import { useCreateEditor } from '../../../hooks/use-create-editor'
 import {
   graphQLErrorMessage,
   Person,
-  Submission,
   useGetPermittedActions,
 } from '../../../lib/lean-workflow-gql'
 import { getUserRole, isAnnotator, isViewer } from '../../../lib/roles'
@@ -61,17 +60,18 @@ import { UserProvider } from './provider/UserProvider'
 import { SaveStatusController } from './SaveStatusController'
 import { TrackChangesStyles } from './TrackChangesStyles'
 
-const ManuscriptPageContainer: React.FC<{
-  submission: Submission
-  person: Person
-}> = ({ submission, person }) => {
-  const [{ project, user }, dispatch] = useStore((state) => {
-    return {
-      manuscriptID: state.manuscriptID,
-      project: state.project,
-      user: state.user,
+const ManuscriptPageContainer: React.FC = () => {
+  const [{ project, user, submission, person }, dispatch] = useStore(
+    (state) => {
+      return {
+        manuscriptID: state.manuscriptID,
+        project: state.project,
+        user: state.user,
+        submission: state.submission,
+        person: state.person,
+      }
     }
-  })
+  )
 
   useEffect(() => {
     if (submission?.id && person) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -28,15 +28,11 @@ import { ThemeProvider } from './theme/ThemeProvider'
 
 export interface ManuscriptEditorAppProps {
   submissionId: string
-  manuscriptID: string
-  projectID: string
   authToken?: string
 }
 
 export const ManuscriptEditorApp: React.FC<ManuscriptEditorAppProps> = ({
   submissionId,
-  manuscriptID,
-  projectID,
   authToken,
 }) => {
   useEffect(() => {
@@ -71,8 +67,6 @@ export const ManuscriptEditorApp: React.FC<ManuscriptEditorAppProps> = ({
             <Main
               // userID={userID}
               submissionId={submissionId}
-              manuscriptID={manuscriptID}
-              projectID={projectID}
             />
           </React.Suspense>
         </ThemeProvider>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -20,6 +20,7 @@ import React, { useEffect } from 'react'
 
 import { IntlProvider } from './components/IntlHookableProvider'
 import { LoadingPage } from './components/Loading'
+import { Person, Submission } from './lib/lean-workflow-gql'
 import tokenHandler from './lib/token'
 import { TokenPayload } from './lib/user'
 import userID from './lib/user-id'
@@ -28,11 +29,19 @@ import { ThemeProvider } from './theme/ThemeProvider'
 
 export interface ManuscriptEditorAppProps {
   submissionId: string
+  manuscriptID: string
+  projectID: string
+  submission: Submission
+  person: Person
   authToken?: string
 }
 
 export const ManuscriptEditorApp: React.FC<ManuscriptEditorAppProps> = ({
   submissionId,
+  manuscriptID,
+  projectID,
+  submission,
+  person,
   authToken,
 }) => {
   useEffect(() => {
@@ -67,6 +76,10 @@ export const ManuscriptEditorApp: React.FC<ManuscriptEditorAppProps> = ({
             <Main
               // userID={userID}
               submissionId={submissionId}
+              manuscriptID={manuscriptID}
+              projectID={projectID}
+              submission={submission}
+              person={person}
             />
           </React.Suspense>
         </ThemeProvider>

--- a/src/lib/lean-workflow-gql.ts
+++ b/src/lib/lean-workflow-gql.ts
@@ -173,6 +173,7 @@ export const GET_SUBMISSION = gql`
   query Submission($id: ID!, $type: SubmissionIDType!) {
     submission(id: $id, type: $type) {
       id
+      documentId
       attachments {
         id
         name
@@ -420,23 +421,15 @@ export const useUpdateAttachmentFile = () => {
   }
 }
 
-export const useGetSubmissionAndPerson = (
-  documentId: string,
-  projectId: string
-) =>
+export const useGetSubmissionAndPerson = (submissionId: string) =>
   useQuery(GET_SUBMISSION, {
     context: {
       clientPurpose: 'leanWorkflowManager',
     },
-    variables: config.submission.id
-      ? {
-          id: config.submission.id,
-          type: 'URI',
-        }
-      : {
-          id: `${projectId}#${documentId}`,
-          type: 'DOCUMENT_ID',
-        },
+    variables: {
+      id: config.submission.id || submissionId,
+      type: 'URI',
+    },
   })
 
 export const useGetCurrentSubmissionStep = (
@@ -577,3 +570,14 @@ export const getErrorCode = (
 ): string | undefined =>
   apolloError?.graphQLErrors.find((error) => error?.extensions?.code)
     ?.extensions?.code.name
+
+export const graphQLErrorMessage = (
+  apolloError: ApolloError,
+  message: string
+) => {
+  return (
+    (apolloError?.networkError &&
+      'Trouble reaching lean server. Please try again.') ||
+    message
+  )
+}

--- a/src/lib/lean-workflow-gql.ts
+++ b/src/lib/lean-workflow-gql.ts
@@ -173,7 +173,6 @@ export const GET_SUBMISSION = gql`
   query Submission($id: ID!, $type: SubmissionIDType!) {
     submission(id: $id, type: $type) {
       id
-      documentId
       attachments {
         id
         name
@@ -268,7 +267,7 @@ const GET_STEP = (stage: string) => gql`
   query Submission($id: ID!, $type: SubmissionIDType!) {
     submission(id: $id, type: $type) {
       id
-       ${stage}Step {
+      ${stage}Step {
         id
         type {
           id
@@ -283,7 +282,7 @@ const GET_STEP = (stage: string) => gql`
           id
           displayName
         }
-       }
+      }
     }
   }
 `
@@ -421,15 +420,23 @@ export const useUpdateAttachmentFile = () => {
   }
 }
 
-export const useGetSubmissionAndPerson = (submissionId: string) =>
+export const useGetSubmissionAndPerson = (
+  documentId: string,
+  projectId: string
+) =>
   useQuery(GET_SUBMISSION, {
     context: {
       clientPurpose: 'leanWorkflowManager',
     },
-    variables: {
-      id: config.submission.id || submissionId,
-      type: 'URI',
-    },
+    variables: config.submission.id
+      ? {
+          id: config.submission.id,
+          type: 'URI',
+        }
+      : {
+          id: `${projectId}#${documentId}`,
+          type: 'DOCUMENT_ID',
+        },
   })
 
 export const useGetCurrentSubmissionStep = (

--- a/src/store/DataSourceStrategy.ts
+++ b/src/store/DataSourceStrategy.ts
@@ -10,6 +10,7 @@
  * All portions of the code written by Atypon Systems LLC are Copyright (c) 2019 Atypon Systems LLC. All Rights Reserved.
  */
 
+import { Person, Submission } from '../lib/lean-workflow-gql'
 import { builderFn, GenericStore, state } from '.'
 
 export type stateSetter = (setState: (currentState: state) => state) => void
@@ -28,6 +29,8 @@ export class BasicSource implements StoreDataSourceStrategy {
     submissionID: string,
     projectID: string,
     manuscriptID: string,
+    submission: Submission,
+    person: Person,
     userID?: string | undefined
   ) {
     this.data = {

--- a/src/store/Store.ts
+++ b/src/store/Store.ts
@@ -38,6 +38,7 @@ import { Commit } from '@manuscripts/track-changes'
 
 import { BiblioTools } from '../couch-data/Bibilo'
 import { TokenData } from '../couch-data/TokenData'
+import { Person, Submission } from '../lib/lean-workflow-gql'
 import { buildStateFromSources, StoreDataSourceStrategy } from '.'
 
 export interface TokenActions {
@@ -83,6 +84,8 @@ export type state = {
   projectInvitations?: ProjectInvitation[]
   containerInvitations?: ContainerInvitation[]
   projects: Project[]
+  submission: Submission
+  person: Person
 
   getModel: <T extends Model>(id: string) => T | undefined
   saveModel: <T extends Model>(model: T | Build<T> | Partial<T>) => Promise<T>


### PR DESCRIPTION
As we are going to use pagination in the dashboard, we will not request all the submissions, so we will utilize `submissionId` to get both `projectID` & `manuscriptID` from [documentId](https://github.com/atypon/leanworkflow-graphql/blob/master/lean-workflow.graphqls#L115).  