### PR TITLE
Get the user profile - LEAN-1244

### DIFF
--- a/src/components/track/Corrections.tsx
+++ b/src/components/track/Corrections.tsx
@@ -66,7 +66,7 @@ export const Corrections: React.FC<Props> = ({
   const [{ project, user, collaboratorsById }] = useStore((store) => ({
     project: store.project,
     user: store.user,
-    collaboratorsById: store.collaboratorsById
+    collaboratorsById: store.collaboratorsById,
   }))
   const getCommitFromCorrectionId = useCallback(
     (correctionId: string) => {

--- a/src/components/track/Corrections.tsx
+++ b/src/components/track/Corrections.tsx
@@ -63,10 +63,10 @@ export const Corrections: React.FC<Props> = ({
   accept,
   reject,
 }) => {
-  const [{ project, user, collaborators }] = useStore((store) => ({
+  const [{ project, user, collaboratorsById }] = useStore((store) => ({
     project: store.project,
     user: store.user,
-    collaborators: store.collaborators || new Map(),
+    collaboratorsById: store.collaboratorsById
   }))
   const getCommitFromCorrectionId = useCallback(
     (correctionId: string) => {
@@ -83,8 +83,8 @@ export const Corrections: React.FC<Props> = ({
   )
 
   const getCollaboratorById = useCallback(
-    (id: string) => collaborators.get(id),
-    [collaborators]
+    (id: string) => collaboratorsById && collaboratorsById.get(id),
+    [collaboratorsById]
   )
 
   const focusCorrection = (correctionId: string) => {


### PR DESCRIPTION
This is to fix the issue reported in LEAN-1244: The user icon is missing from history tab suggestions. 
The icon was missing because the user (currently logged in user) profile does not exist in the `collaborators` list. But it does exist (pushed to) in the map `collaboratorsById`