### PR TITLE
LEAN-2320: Ceres-Stag - published XML does not include changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/article-editor",
-  "version": "1.1.20",
+  "version": "1.1.20-LEAN-2320B",
   "license": "CPAL-1.0",
   "description": "React components for editing and viewing manuscripts",
   "repository": "github:Atypon-OpenSource/manuscripts-article-editor",

--- a/src/hooks/use-handle-snapshot.ts
+++ b/src/hooks/use-handle-snapshot.ts
@@ -28,13 +28,11 @@ export const useHandleSnapshot = (storeExists = true) => {
     const resp = await saveSnapshot(docToJSON())
     if ('data' in resp) {
       execCmd(trackCommands.applyAndRemoveChanges())
-      setTimeout(() => {
-        const state = useEditorStore.getState().editorState
-        if (!state) {
-          return
-        }
-        usePouchStore.getState().saveDoc(getDocWithoutTrackContent(state))
-      })
+      const state = useEditorStore.getState().editorState
+      if (!state) {
+        return
+      }
+      await usePouchStore.getState().saveDoc(getDocWithoutTrackContent(state))
     }
   }
 }


### PR DESCRIPTION
Based on what I read, I believe that `setTimeout` is what's causing the issue of submitting before saving
the `submit` call will not wait for the code inside the `setTimeout` callback to execute. The `setTimeout` function introduces an asynchronous delay, and the subsequent code, including the submit call, will continue executing without waiting for the delay to complete. 
I'm not why its there, but if we need to keep it we need to at least do this
`return async () => {
  const resp = await saveSnapshot(docToJSON())
  if ('data' in resp) {
    execCmd(trackCommands.applyAndRemoveChanges())
    await new Promise((resolve) => {
      setTimeout(() => {
        const state = useEditorStore.getState().editorState
        if (!state) {
          return
        }
        resolve(usePouchStore.getState().saveDoc(getDocWithoutTrackContent(state)))
      })
    })
  }
}`