### PR TITLE
LEAN-3252 Fix for mismatched transactions from inspector after task completed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/article-editor",
-  "version": "1.9.20-LEAN-3252",
+  "version": "1.9.20-LEAN-3252-2",
   "license": "CPAL-1.0",
   "description": "React components for editing and viewing manuscripts",
   "repository": "github:Atypon-OpenSource/manuscripts-article-editor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/article-editor",
-  "version": "1.9.20-LEAN-3252-2",
+  "version": "1.9.20-LEAN-3252-3",
   "license": "CPAL-1.0",
   "description": "React components for editing and viewing manuscripts",
   "repository": "github:Atypon-OpenSource/manuscripts-article-editor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/article-editor",
-  "version": "1.9.20",
+  "version": "1.9.20-LEAN-3252",
   "license": "CPAL-1.0",
   "description": "React components for editing and viewing manuscripts",
   "repository": "github:Atypon-OpenSource/manuscripts-article-editor",

--- a/src/components/projects/ManuscriptPageContainer.tsx
+++ b/src/components/projects/ManuscriptPageContainer.tsx
@@ -152,7 +152,7 @@ const ManuscriptPageView: React.FC = () => {
     const trackState = trackChangesPluginKey.getState(state)
 
     doWithThrottle(() => {
-      storeDispatch({ doc: state.doc, trackState })
+      storeDispatch({ doc: state.doc, trackState, view })
     }, 500)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state])

--- a/src/components/projects/ManuscriptPageContainer.tsx
+++ b/src/components/projects/ManuscriptPageContainer.tsx
@@ -82,7 +82,7 @@ const ManuscriptPageView: React.FC = () => {
   const [doc] = useStore((store) => store.doc)
   const [saveModel] = useStore((store) => store.saveModel)
   const [deleteModel] = useStore((store) => store.deleteModel)
-  const [permittedActions] = useStore((store) => store.permittedActions)
+
   const can = usePermissions()
 
   const editor = useCreateEditor()
@@ -144,15 +144,15 @@ const ManuscriptPageView: React.FC = () => {
   }, [storeDispatch, hasPendingSuggestions])
 
   useEffect(() => {
-    storeDispatch({ editor, view })
-  }, [storeDispatch, view, permittedActions]) // eslint-disable-line react-hooks/exhaustive-deps
+    storeDispatch({ editor })
+  }, [storeDispatch, view]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const doWithThrottle = useDoWithThrottle()
   useEffect(() => {
     const trackState = trackChangesPluginKey.getState(state)
 
     doWithThrottle(() => {
-      storeDispatch({ doc: state.doc, trackState })
+      storeDispatch({ doc: state.doc, trackState, view })
     }, 500)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state])

--- a/src/components/projects/ManuscriptPageContainer.tsx
+++ b/src/components/projects/ManuscriptPageContainer.tsx
@@ -82,7 +82,7 @@ const ManuscriptPageView: React.FC = () => {
   const [doc] = useStore((store) => store.doc)
   const [saveModel] = useStore((store) => store.saveModel)
   const [deleteModel] = useStore((store) => store.deleteModel)
-
+  const [permittedActions] = useStore((store) => store.permittedActions)
   const can = usePermissions()
 
   const editor = useCreateEditor()
@@ -145,14 +145,14 @@ const ManuscriptPageView: React.FC = () => {
 
   useEffect(() => {
     storeDispatch({ editor, view })
-  }, [storeDispatch, view]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [storeDispatch, view, permittedActions]) // eslint-disable-line react-hooks/exhaustive-deps
 
   const doWithThrottle = useDoWithThrottle()
   useEffect(() => {
     const trackState = trackChangesPluginKey.getState(state)
 
     doWithThrottle(() => {
-      storeDispatch({ doc: state.doc, trackState, view })
+      storeDispatch({ doc: state.doc, trackState })
     }, 500)
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state])


### PR DESCRIPTION
View needs to be updated, otherwise it becomes stale on task completion which causes useCmd to apply transactions on an outdated doc.