### PR TITLE
Unexclude Project and Manuscript models from the saved models 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/article-editor",
-  "version": "1.14.3-LEAN-3660.0",
+  "version": "1.14.3",
   "license": "CPAL-1.0",
   "description": "React components for editing and viewing manuscripts",
   "repository": "github:Atypon-OpenSource/manuscripts-article-editor",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/article-editor",
-  "version": "1.14.2",
+  "version": "1.14.3-LEAN-3660.0",
   "license": "CPAL-1.0",
   "description": "React components for editing and viewing manuscripts",
   "repository": "github:Atypon-OpenSource/manuscripts-article-editor",

--- a/src/postgres-data/buildUtilities.ts
+++ b/src/postgres-data/buildUtilities.ts
@@ -27,7 +27,10 @@ export const buildUtilities = (
   updateState: (state: Partial<state>) => void,
   api: Api
 ): Partial<state> => {
-  const excludeTypes = new Set([ObjectTypes.Manuscript, ObjectTypes.Project])
+  const nonPMModelsTypes = new Set([
+    ObjectTypes.Manuscript,
+    ObjectTypes.Project,
+  ])
 
   const updateContainerIDs = (
     model: Model,
@@ -88,7 +91,7 @@ export const buildUtilities = (
 
     for (const [id, model] of state.modelMap) {
       const type = model.objectType as ObjectTypes
-      if (!excludeTypes.has(type) && !excludeIDs?.has(id)) {
+      if (nonPMModelsTypes.has(type) || !excludeIDs?.has(id)) {
         modelMap.set(id, model)
       }
     }


### PR DESCRIPTION
I see this was recently changed, and by doing this we're deleting the project & manuscript models