### PR TITLE
LEAN-3577

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@manuscripts/article-editor",
-  "version": "1.17.8",
+  "version": "1.17.9",
   "license": "CPAL-1.0",
   "description": "React components for editing and viewing manuscripts",
   "repository": "github:Atypon-OpenSource/manuscripts-article-editor",

--- a/src/postgres-data/buildData.ts
+++ b/src/postgres-data/buildData.ts
@@ -75,8 +75,15 @@ const getUserData = async (projectID: string, user: UserProfile, api: Api) => {
 }
 
 const createDoc = (modelMap: Map<string, Model>) => {
-  const decoder = new Decoder(modelMap, true)
-  return decoder.createArticleNode()
+  try {
+    const decoder = new Decoder(modelMap, true)
+    return decoder.createArticleNode()
+  } catch (e) {
+    console.warn(
+      'Unable to produce a document from the json models with error: ' + e
+    )
+    return null
+  }
 }
 
 export const buildData = async (

--- a/src/quarterback/QuarterBackDataSource.ts
+++ b/src/quarterback/QuarterBackDataSource.ts
@@ -31,7 +31,7 @@ export default class QuarterbackDataSource implements StoreDataSourceStrategy {
     this.loadDoc = loadDoc
   }
   build: builderFn = async (state, next) => {
-    if (state.projectID && state.manuscriptID && state.doc) {
+    if (state.projectID && state.manuscriptID) {
       const res = await this.loadDoc(
         state.manuscriptID,
         state.projectID,

--- a/src/quarterback/api/document.ts
+++ b/src/quarterback/api/document.ts
@@ -9,6 +9,7 @@
  *
  * All portions of the code written by Atypon Systems LLC are Copyright (c) 2022 Atypon Systems LLC. All Rights Reserved.
  */
+import { getVersion } from '@manuscripts/transform'
 import { EventSourceMessage } from '@microsoft/fetch-event-source'
 
 import {
@@ -102,6 +103,13 @@ export const listenStepUpdates = (
   const listener = (event: EventSourceMessage) => {
     if (event.data) {
       const data = JSON.parse(event.data)
+      if (data.transformVersion && data.transformVersion !== getVersion()) {
+        console.warn(
+          `Warning! Manuscripts-transform (Frontend: ${getVersion()}) version is different on manuscripts-api (${
+            data.transformVersion
+          })`
+        )
+      }
       if (
         typeof data.version != 'undefined' &&
         data.steps &&

--- a/src/quarterback/api/methods.ts
+++ b/src/quarterback/api/methods.ts
@@ -169,13 +169,6 @@ export async function listen<T>(
         response.ok &&
         response.headers.get('content-type') === 'text/event-stream'
       ) {
-        if (response.headers.get('Transform-Version') !== getVersion()) {
-          console.warn(
-            `Warning! Manuscripts-transform (Frontend: ${getVersion()}) version is different on backend (${response.headers.get(
-              'Transform-Version'
-            )})`
-          )
-        }
         console.log('EventSource Connection Opened Ok')
         return
       } else if (

--- a/src/quarterback/useLoadDoc.ts
+++ b/src/quarterback/useLoadDoc.ts
@@ -20,7 +20,7 @@ export const useLoadDoc = (authToken: string) => {
   return async function loadDoc(
     manuscriptID: string,
     projectID: string,
-    existingDoc: ManuscriptNode
+    existingDoc?: ManuscriptNode
   ) {
     const found = await docApi.getDocument(projectID, manuscriptID, authToken)
     let doc
@@ -34,6 +34,11 @@ export const useLoadDoc = (authToken: string) => {
       }
 
       if (empty) {
+        if (!existingDoc) {
+          throw new Error(
+            'Unable to produce valid doc as neither model based verions nor history have a valid version'
+          )
+        }
         await updateDocument(projectID, manuscriptID, authToken, {
           doc: existingDoc.toJSON(),
           schema_version: getVersion(),
@@ -64,7 +69,7 @@ export const useLoadDoc = (authToken: string) => {
       }
 
       const update = await updateDocument(projectID, manuscriptID, authToken, {
-        doc: existingDoc.toJSON(),
+        doc: existingDoc?.toJSON(),
         schema_version: getVersion(),
       })
       if ('err' in update) {


### PR DESCRIPTION
Since we are supporting migration of prosemirror schema only, we need to be able to skip the doc creation from json-schema models, if it fails due to schema changes. We always do that before reaching out to the prosemirror document in the history.

Also version comparison changed from headers to data as it's not possible to read headers in our setup.