### PR TITLE
LEAN-3843 Improve steps communication between FE and BE

### DIFF
--- a/src/api/Api.ts
+++ b/src/api/Api.ts
@@ -34,13 +34,15 @@ import {
 
 export class Api {
   instance: AxiosInstance
-
+  ws: WebSocket
+  token: string
   constructor(authToken: string) {
     const config = getConfig()
     this.instance = axios.create({
       baseURL: config.api.url,
       headers: { ...config.api.headers, Authorization: 'Bearer ' + authToken },
     })
+    this.token = authToken
   }
 
   get = async <T>(url: string) => {
@@ -58,6 +60,7 @@ export class Api {
   }
 
   post = async <T>(path: string, data: unknown) => {
+    console.log('post', path, data)
     return this.instance
       .post<T>(path, data)
       .then((result) => result.data)
@@ -171,8 +174,6 @@ export class Api {
     const base = config.api.url.replace('http', 'ws')
     const url = `${base}/doc/${projectID}/manuscript/${manuscriptID}/listen`
 
-    let ws: WebSocket
-
     const onOpen = () => {
       console.log('Established WebSocket connection')
     }
@@ -204,14 +205,14 @@ export class Api {
     }
 
     const close = () => {
-      if (!ws) {
+      if (!this.ws) {
         return
       }
-      ws.removeEventListener('open', onOpen)
-      ws.removeEventListener('message', onMessage)
-      ws.removeEventListener('close', onClose)
-      ws.removeEventListener('error', onError)
-      ws.close()
+      this.ws.removeEventListener('open', onOpen)
+      this.ws.removeEventListener('message', onMessage)
+      this.ws.removeEventListener('close', onClose)
+      this.ws.removeEventListener('error', onError)
+      this.ws.close()
     }
 
     const rejoin = () => {
@@ -221,11 +222,11 @@ export class Api {
 
     const join = () => {
       try {
-        ws = new WebSocket(url)
-        ws.addEventListener('open', onOpen)
-        ws.addEventListener('message', onMessage)
-        ws.addEventListener('close', onClose)
-        ws.addEventListener('error', onError)
+        this.ws = new WebSocket(url)
+        this.ws.addEventListener('open', onOpen)
+        this.ws.addEventListener('message', onMessage)
+        this.ws.addEventListener('close', onClose)
+        this.ws.addEventListener('error', onError)
       } catch (e) {
         console.log(e)
         rejoin()


### PR DESCRIPTION
@mnatsheh, I have made the following changes:

1. made the current web-socket connection generic in order to reuse it instead of establishing a new one.
2. I have kept the HTTP request as a fallback if the web socket connection not established correctly.
3. I am sending the token in the payload in order to validate the request and fetch the retrieve the user in the API using it.

here is the API pr: https://github.com/Atypon-OpenSource/manuscripts-api/pull/188

and would you please elaborate more on this: "The steps received on the websocket should be used instead of issuing a separate request to load steps."